### PR TITLE
Update README for 2025 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 --
 
-Updated on 17 Sep. 2024:
+Updated on 17 Sep. 2025:
 
 Update ngx_pagespeed.cc
 Updated ps_get_cache_control: 
@@ -32,7 +32,7 @@ workflow. Features include:
   [more](https://developers.google.com/speed/docs/mod_pagespeed/config_filters)
 
 To see ngx_pagespeed in action, with example pages for each of the
-optimizations, see our <a href="http://ngxpagespeed.com">demonstration site</a>.
+optimizations, see our <a href="https://ngxpagespeed.com">demonstration site</a>.
 
 ## How to build
 


### PR DESCRIPTION
## Summary
- update the update date to 2025
- use HTTPS demo link in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e26e50988326a31787ba2525316d