### PR TITLE
Reintroduce pre-1.23 cache-control handling

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -397,9 +397,11 @@ namespace {
 // Based on ngx_http_add_cache_control.
 ngx_int_t ps_set_cache_control(ngx_http_request_t* r,
                                const char* cache_control_value) {
-  // Check if cache_control is already set
+#if defined(nginx_version) && nginx_version >= 1023000
+  // Nginx 1.23+ stores Cache-Control as a linked list starting at
+  // headers_out.cache_control. Allocate the first element if needed using
+  // ngx_pcalloc as done in the 2025 code base.
   if (r->headers_out.cache_control == nullptr) {
-    // Allocate memory for a single cache_control element
     r->headers_out.cache_control = static_cast<ngx_table_elt_t*>(
         ngx_pcalloc(r->pool, sizeof(ngx_table_elt_t)));
     if (r->headers_out.cache_control == nullptr) {
@@ -407,14 +409,62 @@ ngx_int_t ps_set_cache_control(ngx_http_request_t* r,
     }
   }
 
-  // Set the cache control header value
-  r->headers_out.cache_control->hash = 1;
-  r->headers_out.cache_control->key.len = sizeof("Cache-Control") - 1;
-  r->headers_out.cache_control->key.data = (u_char*)"Cache-Control";
-  r->headers_out.cache_control->value.len = strlen(cache_control_value);
-  r->headers_out.cache_control->value.data =
-      reinterpret_cast<u_char*>(const_cast<char*>(cache_control_value));
+  ngx_table_elt_t* cc = r->headers_out.cache_control;
 
+  // Clear any additional Cache-Control entries.
+  for (cc = cc->next; cc != NULL; cc = cc->next) {
+    cc->hash = 0;
+  }
+
+  cc = r->headers_out.cache_control;
+  cc->next = NULL;
+
+  // Set the cache control header value.
+  cc->hash = 1;
+  cc->key.len = sizeof("Cache-Control") - 1;
+  cc->key.data = reinterpret_cast<u_char*>(const_cast<char*>("Cache-Control"));
+  cc->value.len = strlen(cache_control_value);
+  cc->value.data =
+      reinterpret_cast<u_char*>(const_cast<char*>(cache_control_value));
+#else
+  // Pre-1.23 nginx stores Cache-Control in an array.  First remove any existing
+  // cache-control headers from the output list.
+  ngx_table_elt_t* header;
+  NgxListIterator it(&(r->headers_out.headers.part));
+  while ((header = it.Next()) != NULL) {
+    if (STR_CASE_EQ_LITERAL(header->key, "Cache-Control")) {
+      // Response headers with hash of 0 are excluded from the response.
+      header->hash = 0;
+    }
+  }
+
+  // Create the array if this is the first header being added.
+  if (r->headers_out.cache_control.elts == NULL) {
+    ngx_int_t rc = ngx_array_init(&r->headers_out.cache_control, r->pool,
+                                  1, sizeof(ngx_table_elt_t*));
+    if (rc != NGX_OK) {
+      return NGX_ERROR;
+    }
+  }
+
+  ngx_table_elt_t** cache_control_headers = static_cast<ngx_table_elt_t**>(
+      ngx_array_push(&r->headers_out.cache_control));
+  if (cache_control_headers == NULL) {
+    return NGX_ERROR;
+  }
+
+  cache_control_headers[0] = static_cast<ngx_table_elt_t*>(
+      ngx_list_push(&r->headers_out.headers));
+  if (cache_control_headers[0] == NULL) {
+    return NGX_ERROR;
+  }
+
+  cache_control_headers[0]->hash = 1;
+  ngx_str_set(&cache_control_headers[0]->key, "Cache-Control");
+  cache_control_headers[0]->value.len = strlen(cache_control_value);
+  cache_control_headers[0]->value.data =
+      reinterpret_cast<u_char*>(const_cast<char*>(cache_control_value));
+#endif
   return NGX_OK;
 }
 
@@ -422,22 +472,44 @@ ngx_int_t ps_set_cache_control(ngx_http_request_t* r,
 // Returns false if the header wasn't found.  Otherwise sets cache_control and
 // returns true;
 bool ps_get_cache_control(ngx_http_request_t* r, GoogleString* cache_control) {
-  // Use headers_out.cache_control directly, as it's a single pointer now.
-  ngx_table_elt_t* ccp = r->headers_out.cache_control;  // No need to access `elts`
+#if defined(nginx_version) && nginx_version >= 1023000
+  // Nginx 1.23+ exposes cache_control as a linked list starting at
+  // headers_out.cache_control.
+  ngx_table_elt_t* cc = r->headers_out.cache_control;
+  bool first_segment = true;
 
+  while (cc != NULL) {
+    if (cc->hash) {
+      if (first_segment) {
+        first_segment = false;
+      } else {
+        cache_control->append(", ");
+      }
+      cache_control->append(reinterpret_cast<char*>(cc->value.data),
+                            cc->value.len);
+    }
+    cc = cc->next;
+  }
+#else
+  // Older nginx versions store cache_control as an array of pointers.
+  auto ccp = static_cast<ngx_table_elt_t**>(r->headers_out.cache_control.elts);
   if (ccp == nullptr) {
     return false;  // Header not present.
   }
-
   bool first_segment = true;
-  // Since it's no longer an array, you only need to handle one element.
-  if (ccp->hash != 0) {  // Elements with a hash of 0 are marked as excluded.
-    if (!first_segment) {
+  for (ngx_uint_t i = 0; i < r->headers_out.cache_control.nelts; i++) {
+    if (ccp[i]->hash == 0) {
+      continue;  // Elements with a hash of 0 are marked as excluded.
+    }
+    if (first_segment) {
+      first_segment = false;
+    } else {
       cache_control->append(", ");
     }
-    cache_control->append(reinterpret_cast<char*>(ccp->value.data), ccp->value.len);
+    cache_control->append(reinterpret_cast<char*>(ccp[i]->value.data),
+                          ccp[i]->value.len);
   }
-
+#endif
   return true;
 }
 


### PR DESCRIPTION
## Summary
- support both nginx <1.23 and >=1.23 in `ps_set_cache_control` and `ps_get_cache_control`
- keep modern allocation with `ngx_pcalloc` for new nginx versions

## Testing
- `bash test/run_tests.sh` *(fails: Makefile.tests missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859e4d566708326b880a18099c74457